### PR TITLE
Minor tweak to $windowsDefaultPath

### DIFF
--- a/FFEncoder.ps1
+++ b/FFEncoder.ps1
@@ -368,7 +368,7 @@ param (
 #Change these to modify the default path for generated files when a regex match cannot be made
 $macDefaultPath = '~/Movies'
 $linuxDefaultPath = '~/Videos'
-$windowsDefaultPath = "C:\Users\$env:USERNAME\Videos"
+$windowsDefaultPath = "$env:USERPROFILE\Videos"
 
 ## End Global Variables ##
 


### PR DESCRIPTION
Exchanges `C:\Users\$env:USERNAME\Videos` for `$env:USERPROFILE\Videos`

Almost every Windows installation ever uses the C drive, but still, might as well.