### PR TITLE
Minor tweak to $windowsDefaultPath (again)

### DIFF
--- a/FFEncoder.ps1
+++ b/FFEncoder.ps1
@@ -397,7 +397,7 @@ param (
 #Change these to modify the default path for generated files when a regex match cannot be made
 $macDefaultPath = '~/Movies'
 $linuxDefaultPath = '~/Videos'
-$windowsDefaultPath = "$env:USERPROFILE\Videos"
+$windowsDefaultPath = [Environment]::GetFolderPath('MyVideos')
 
 ## End Global Variables ##
 


### PR DESCRIPTION
Uses `[Environment]::GetFolderPath('MyVideos')`, didn't know this was even a thing until the other day and I didn't think to revise my earlier PR until I saw the merge notification email (because I found it in the context of someone using it for getting the Documents folder).

This is a particularly good change because there is an obscure way to change your default videos folder that almost no one ever does:

![image](https://user-images.githubusercontent.com/53661808/134068458-dddeba23-a3fe-4af5-965d-a97d3e1efda8.png)