### PR TITLE
Progress bug fix

### DIFF
--- a/modules/FFTools/FFTools.psd1
+++ b/modules/FFTools/FFTools.psd1
@@ -91,7 +91,8 @@ AliasesToExport = 'iffmpeg', 'cropfile', 'cropdim'
 FileList = 'FFTools.psd1', 'FFTools.psm1', 'Private\Set-AudioPreference.ps1', 'Private\Get-SubtitleStream', 'Private\Set-SubtitlePreference',
     'Private\Get-HDRMetadata.ps1', 'Public\Invoke-FFMpeg.ps1', 'Public\Invoke-TwoPassFFMpeg.ps1', 'Public\New-CropFile.ps1', 'Public\Measure-CropDimensions.ps1', 'Public\Invoke-VMAF.ps1',
     'Private\ConvertTo-Stereo.ps1', 'Private\Set-PresetParameters.ps1', 'Private\Set-FFMPegArgs.ps1', 'Private\Set-VideoFilter.ps1', 'Private\Set-TestParameters.ps1',
-    'Private\Confirm-Parameters.ps1', 'Private\Set-DVArgs.ps1', 'Utils\Invoke-DeeEncoder.ps1','Utils\Confirm-ScaleFilter.ps1','Utils\Write-Report.ps1',
+    'Private\Watch-ScriptTerminated.ps1', 'Private\Confirm-Parameters.ps1', 'Private\Set-DVArgs.ps1',
+    'Utils\Invoke-DeeEncoder.ps1','Utils\Confirm-ScaleFilter.ps1','Utils\Write-Report.ps1',
     'Utils\Invoke-MkvMerge.ps1', 'Utils\Confirm-HDR10Plus.ps1', 'Utils\Confirm-DolbyVision.ps1', 'Utils\Remove-FilePrompt.ps1', 'Utils\Read-Config.ps1'
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/modules/FFTools/FFTools.psm1
+++ b/modules/FFTools/FFTools.psm1
@@ -66,6 +66,10 @@ $Script:dee = @{
     DeeArgs = @('dee_ddp', 'dee_eac3', 'dee_dd', 'dee_ac3', 'dee_thd', 'dee_ddp_51', 'dee_eac3_51')
     DeeUsed = $false
 }
+# Keep track of frame count for 2-pass encodes
+$Script:frame = @{
+    FrameCount = 0
+}
 
 # Detect operating system info
 if ($isMacOs) {
@@ -133,7 +137,7 @@ ___________      .__  __  .__                 ______________________            
 '@
 
 # Current script release version
-[version]$release = '2.2.0'
+[version]$release = '2.2.1'
 
 
 #### End module variables ####

--- a/modules/FFTools/Private/Watch-ScriptTerminated.ps1
+++ b/modules/FFTools/Private/Watch-ScriptTerminated.ps1
@@ -1,0 +1,31 @@
+<#
+    .SYNOPSIS
+        Watches for CTRL+C interrupts and clean exits all running jobs and scripts
+#>
+function Watch-ScriptTerminated {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$Message
+    )
+
+    if ($Host.UI.RawUI.KeyAvailable -and ($key = $Host.UI.RawUI.ReadKey("AllowCtrlC,NoEcho,IncludeKeyUp"))) {
+        # If user hits Ctrl+C
+        if ([int]$key.Character -eq 3) {
+            Write-Progress "Terminated" -Completed
+            Write-Warning "CTRL+C was detected - shutting down all running jobs before exiting the script"
+            # Clean up all running jobs before exiting
+            Get-Job | Stop-Job -PassThru | Remove-Job -Force -Confirm:$false
+
+            $psReq ? (Write-Host "$($aRed)$Message$($reset)") :
+                     (Write-Host $Message @errColors)
+
+            $console.WindowTitle = $currentTitle
+            [console]::TreatControlCAsInput = $false
+            exit 77
+        }
+
+        # Flush the key buffer again for the next loop
+        $Host.UI.RawUI.FlushInputBuffer()
+    }
+}


### PR DESCRIPTION
Fix bug crash for 2-pass encodes. Progress bar did not have a frame count for the second pass, causing an indexing error. Also wrapped every progress function call in try/catch so there should never be another terminating error again from that damn function.