### PR TITLE
Bug fixes config update

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ To use this parameter, you will need a valid TMDB API key. See [the wiki](https:
 
 ### Configuration Files
 
-Two configuration files, `ffmpeg.ini` and `encoder.ini`, are included and can be used to set frequently used options not covered by script parameters. These files are located in the `config` directory and are loaded each time the script runs.
+Three configuration files, `ffmpeg.ini`, `encoder.ini`, and `script.ini`, are included and can be leveraged to set frequently used options. These files are located in the `config` directory and are loaded each time the script runs.
 
-See the wiki for more information.
+See [the wiki](https://github.com/patrickenfuego/FFEncoder/wiki/Configuration-Files) for more information.
 
 FFEncoder can accept the following parameters from the command line:
 
@@ -214,6 +214,8 @@ FFEncoder can accept the following parameters from the command line:
 ### Audio & Subtitles
 
 > See [Audio Options](https://github.com/patrickenfuego/FFEncoder/wiki/Audio-Options) and [Subtitle Options](https://github.com/patrickenfuego/FFEncoder/wiki/Subtitle-Options) in the wiki for more info
+
+> Using deew requires some initial configuration before it will work properly. See [the wiki](https://github.com/patrickenfuego/FFEncoder/wiki/Audio-Options#using-the-dee-encoding-options) for more info
 
 | Parameter Name    | Default | Mandatory | Alias                  | Description                                                                                                         |
 | ----------------- | ------- | --------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/bin/windows/dee_wrapper/config.toml
+++ b/bin/windows/dee_wrapper/config.toml
@@ -28,8 +28,8 @@ max_instances = '50%'
     dd_5_1 = 640
     ddp_1_0 = 128
     ddp_2_0 = 256
-    ddp_5_1 = 1024
-    ddp_7_1 = 1536
+    ddp_5_1 = 768
+    ddp_7_1 = 1280
 
 # You can toggle what sections you would like to see in the encoding summary
 [summary_sections]

--- a/config/script.ini
+++ b/config/script.ini
@@ -1,0 +1,8 @@
+[Script]
+RemoveFiles=False
+DisableProgress=False
+ExitOnError=False
+SkipHDR10Plus=False
+SkipDolbyVision=False
+GenerateReport=False
+HDR10PlusSkipReorder=False

--- a/modules/FFTools/FFTools.psd1
+++ b/modules/FFTools/FFTools.psd1
@@ -70,7 +70,7 @@ PowerShellVersion = '7.0'
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = 'Invoke-FFMpeg', 'Invoke-TwoPassFFMpeg', 'New-CropFile', 'Measure-CropDimensions', 'Remove-FilePrompt', 'Write-Report', 'Confirm-HDR10Plus',
-                    'Confirm-DolbyVision', 'Confirm-ScaleFilter', 'Invoke-MkvMerge', 'Invoke-DeeEncoder', 'Read-TimedInput', 'Invoke-VMAF', 'Read-Config'
+                    'Confirm-DolbyVision', 'Confirm-ScaleFilter', 'Invoke-MkvMerge', 'Invoke-DeeEncoder', 'Read-TimedInput', 'Invoke-VMAF', 'Import-Config'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 # CmdletsToExport = @()
@@ -91,9 +91,9 @@ AliasesToExport = 'iffmpeg', 'cropfile', 'cropdim'
 FileList = 'FFTools.psd1', 'FFTools.psm1', 'Private\Set-AudioPreference.ps1', 'Private\Get-SubtitleStream', 'Private\Set-SubtitlePreference',
     'Private\Get-HDRMetadata.ps1', 'Public\Invoke-FFMpeg.ps1', 'Public\Invoke-TwoPassFFMpeg.ps1', 'Public\New-CropFile.ps1', 'Public\Measure-CropDimensions.ps1', 'Public\Invoke-VMAF.ps1',
     'Private\ConvertTo-Stereo.ps1', 'Private\Set-PresetParameters.ps1', 'Private\Set-FFMPegArgs.ps1', 'Private\Set-VideoFilter.ps1', 'Private\Set-TestParameters.ps1',
-    'Private\Watch-ScriptTerminated.ps1', 'Private\Confirm-Parameters.ps1', 'Private\Set-DVArgs.ps1', 'Private\Edit-RPU.ps1', 'Private\Import-Config.ps1',
-    'Utils\Invoke-DeeEncoder.ps1','Utils\Confirm-ScaleFilter.ps1','Utils\Write-Report.ps1',
-    'Utils\Invoke-MkvMerge.ps1', 'Utils\Confirm-HDR10Plus.ps1', 'Utils\Confirm-DolbyVision.ps1', 'Utils\Remove-FilePrompt.ps1', 'Utils\Read-Config.ps1'
+    'Private\Watch-ScriptTerminated.ps1', 'Private\Confirm-Parameters.ps1', 'Private\Set-DVArgs.ps1', 'Private\Edit-RPU.ps1', 'Private\Read-Config.ps1',
+    'Utils\Invoke-DeeEncoder.ps1','Utils\Confirm-ScaleFilter.ps1','Utils\Write-Report.ps1', 'Utils\Import-Config.ps1',
+    'Utils\Invoke-MkvMerge.ps1', 'Utils\Confirm-HDR10Plus.ps1', 'Utils\Confirm-DolbyVision.ps1', 'Utils\Remove-FilePrompt.ps1'
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{

--- a/modules/FFTools/FFTools.psm1
+++ b/modules/FFTools/FFTools.psm1
@@ -138,7 +138,7 @@ ___________      .__  __  .__                 ______________________            
 '@
 
 # Current script release version
-[version]$release = '2.4.0'
+[version]$release = '2.4.1'
 
 
 #### End module variables ####
@@ -190,7 +190,7 @@ New-Alias -Name cropdim -Value Measure-CropDimensions -Force
 $ExportModule = @{
     Alias    = @('iffmpeg', 'cropfile', 'cropdim')
     Function = @('Invoke-FFmpeg', 'Invoke-TwoPassFFmpeg', 'New-CropFile', 'Measure-CropDimensions', 'Remove-FilePrompt', 'Write-Report', 'Confirm-HDR10Plus',
-                 'Confirm-DolbyVision', 'Confirm-ScaleFilter', 'Invoke-MkvMerge', 'Invoke-DeeEncoder', 'Read-TimedInput', 'Invoke-VMAF', 'Read-Config')
+                 'Confirm-DolbyVision', 'Confirm-ScaleFilter', 'Invoke-MkvMerge', 'Invoke-DeeEncoder', 'Read-TimedInput', 'Invoke-VMAF', 'Import-Config')
     Variable = @('progressColors', 'warnColors', 'emphasisColors', 'errColors', 'osInfo', 'banner1', 'banner2', 'exitBanner', 'ScriptsDirectory',
                  'release' )
 }

--- a/modules/FFTools/Private/Set-DVArgs.ps1
+++ b/modules/FFTools/Private/Set-DVArgs.ps1
@@ -230,7 +230,7 @@ function Set-DVArgs {
         }
     }
 
-    # Add parameters passed via -x265Extra
+    # Add parameters passed via -EncoderExtra
     if ($PSBoundParameters['EncoderExtra']) {
         $x265ExtraArray = [ArrayList]@()
         foreach ($arg in $EncoderExtra.GetEnumerator()) {
@@ -301,7 +301,7 @@ function Set-DVArgs {
         '-probesize'
         '100MB'
         '-i'
-        if ($psReq) {
+        if ($PSVersionTable.PSVersion -lt [version]'7.3') {
             $($Paths.InputFile)
         }
         else {
@@ -486,7 +486,7 @@ function Set-DVArgs {
             '*k' {
                 [int]( $_ -replace 'k', '')
             }
-            default { Write-Error "Unknown bitrate suffix for two pass" -ErrorAction Stop }
+            default { Write-Error "Unknown bitrate suffix for two pass encode" -ErrorAction Stop }
         }
         $x265BaseArray.AddRange(@('--bitrate', $val))
     }

--- a/modules/FFTools/Utils/Invoke-DeeEncoder.ps1
+++ b/modules/FFTools/Utils/Invoke-DeeEncoder.ps1
@@ -36,8 +36,8 @@ function Invoke-DeeEncoder {
         [switch]$Stereo
     )
 
-    $logPath = [Path]::Join($(Split-Path $Paths.InputFile -Parent), 'dee.log')
-    $outputPath = Split-Path $Paths.OutputFile -Parent
+    $logPath = [Path]::Join(([FileInfo]$Paths.InputFile).DirectoryName, 'dee.log')
+    $outputPath = ([FileInfo]$Paths.OutputFile).DirectoryName
 
     Write-Output "Preparing DEE encoder..." >$logPath
     Write-Verbose "Parameters:`n`n$([pscustomobject]$PSBoundParameters | Out-String)" 4>>$logPath
@@ -59,7 +59,7 @@ function Invoke-DeeEncoder {
     }
 
     $audioBase = ($Paths.InputFile.EndsWith('mkv')) ? ("$($Paths.Title)_audio.mka") : ("$($Paths.Title)_audio.m4a")
-    $Paths.AudioPath = [Path]::Join($(Split-Path $Paths.InputFile -Parent), $audioBase)
+    $Paths.AudioPath = [Path]::Join(([FileInfo]$Paths.InputFile).DirectoryName, $audioBase)
 
     if (![File]::Exists($Paths.AudioPath)) {
         Write-Verbose "ThreadJob: Multiplexing audio for DEE...`n" 4>>$logPath
@@ -88,7 +88,7 @@ function Invoke-DeeEncoder {
     }
 
     # Create the directory structure
-    $tmpPath = [Path]::Join($(Split-Path $Paths.InputFile -Parent), 'dee_tmp')
+    $tmpPath = [Path]::Join(([FileInfo]$Paths.InputFile).DirectoryName, 'dee_tmp')
     if (![Directory]::Exists($tmpPath)) {
         [Directory]::CreateDirectory($tmpPath) > $null
     }

--- a/scripts/VerifyVersions.ps1
+++ b/scripts/VerifyVersions.ps1
@@ -59,7 +59,7 @@ function Confirm-PoshVersion {
         $console.WindowTitle = $currentTitle
         Write-Error @params -ErrorAction Stop
     }
-    elseif (($PSVersionTable.PSVersion -lt [version]'7.3.0.0')) {
+    elseif (($PSVersionTable.PSVersion -lt [version]'7.2.0.0')) {
         $latestRelease = Get-ReleaseVersion -Repository Pwsh
         
         Write-Host "You are not running the latest version of PowerShell 7:" @warnColors


### PR DESCRIPTION
## What's New

Several bug fixes and a new config file for script switch parameters.

### Updates

- A new config file is available for script switch parameters. Config options can be set in the file instead of having to pass a parameter each time. If the parameter is passed, it overrides the configuration file
- More .NET performance enhancements
- Updated deew default bitrates

### Bug Fixes

- Fixed VapourSynth script muxing for audio, subs, and chapters. These were not being copied before
- Fixed additional string parsing bugs from PowerShell 7.3 update
- Extract chapters using ffmpeg during DoVi encodes if `mkvextract` isn't available
- Fixed lossy audio warning for some DTS-HD MA tracks
- Fixed issue where parameter options were ignored in the encoder config file. If a script parameter is passed, it overrides the config